### PR TITLE
Separate email to include |safe_email filter

### DIFF
--- a/pages/01.home/_about/about.md
+++ b/pages/01.home/_about/about.md
@@ -6,7 +6,8 @@ address:
     - line: 1600 Amphitheatre Parkway
     - line: Mountain View, CA 94043 US
     - line: (123)456-7890
-    - line: anyone@website.com
+email:
+    - address: anyone@website.com
 buttons:
     - url: "#"
       icon: download


### PR DESCRIPTION
Separating the email address to it's own variable allows for the use of the twig filter "|safe_email" to be used in the template

A pull request of the same subject is made on the theme alone to work with the changes in the frontmatter here