### PR TITLE
Fix contact form wrong 'to' address

### DIFF
--- a/pages/01.home/modular.md
+++ b/pages/01.home/modular.md
@@ -39,7 +39,7 @@ form:
         - email:
             from: "{{ config.plugins.email.from }}"
             to:
-              - "{{ config.plugins.email.from }}"
+              - "{{ config.plugins.email.to }}"
               - "{{ form.value.email }}"
             subject: "[Feedback] {{ form.value.name|e }}"
             body: "{% include 'forms/data.html.twig' %}"


### PR DESCRIPTION
Use email 'to' field instead of 'from' field to send the email to.